### PR TITLE
Fix Firefox playback issue

### DIFF
--- a/examples/resources/js/benchmark.js
+++ b/examples/resources/js/benchmark.js
@@ -113,6 +113,7 @@ function startBenchmark() {
 
   let audioElement = document.createElement('audio');
   audioElement.src = 'resources/cube-sound.wav';
+  audioElement.crossOrigin = 'anonymous';
   audioElement.load();
   audioElement.loop = true;
   let audioElementSource = audioContext.createMediaElementSource(audioElement);

--- a/examples/resources/js/birds.js
+++ b/examples/resources/js/birds.js
@@ -148,6 +148,7 @@ function initAudio() {
       Math.round(Math.random() * (audioSources.length - 1));
     audioElements[i] = document.createElement('audio');
     audioElements[i].src = audioSources[birdIndex];
+    audioElements[i].crossOrigin = 'anonymous';
     audioElements[i].load();
     audioElements[i].loop = true;
     audioElementSources[i] =

--- a/examples/resources/js/hello-world.js
+++ b/examples/resources/js/hello-world.js
@@ -36,6 +36,7 @@ function initAudio() {
   // Create an audio element. Feed into audio graph.
   audioElement = document.createElement('audio');
   audioElement.src = 'resources/cube-sound.wav';
+  audioElement.crossOrigin = 'anonymous';
   audioElement.load();
   audioElement.loop = true;
 

--- a/examples/resources/js/room-models.js
+++ b/examples/resources/js/room-models.js
@@ -94,6 +94,7 @@ function initAudio() {
   for (let i = 0; i < audioSources.length; i++) {
     audioElements[i] = document.createElement('audio');
     audioElements[i].src = audioSources[i];
+    audioElements[i].crossOrigin = 'anonymous';
     audioElements[i].load();
     audioElements[i].loop = true;
     audioElementSources[i] =

--- a/examples/resources/js/treasure-hunt.js
+++ b/examples/resources/js/treasure-hunt.js
@@ -207,6 +207,7 @@ function initAudio() {
   source = audioScene.createSource();
   audioElement = document.createElement('audio');
   audioElement.src = 'resources/cube-sound.wav';
+  audioElement.crossOrigin = 'anonymous';
   audioElement.load();
   audioElement.loop = true;
   audioElementSource =

--- a/examples/resources/js/vs-pannernode.js
+++ b/examples/resources/js/vs-pannernode.js
@@ -93,6 +93,7 @@ function initAudio() {
   let audioSource = 'resources/cube-sound.wav';
   audioElement = document.createElement('audio');
   audioElement.src = audioSource;
+  audioElement.crossOrigin = 'anonymous';
   audioElement.load();
   audioElement.loop = true;
   audioElementSource =


### PR DESCRIPTION
Fixes #8 by adding the `crossOrigin` property to the `audio`elements in .../examples. 
Please see [this](https://bugzilla.mozilla.org/show_bug.cgi?id=937718) bug for more info.