### PR TITLE
Update to newest version of Omnitone

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "doctoc": "^1.3.0"
   },
   "dependencies": {
-    "omnitone": "^1.0.5"
+    "omnitone": "^1.2.4"
   },
   "scripts": {
     "build": "webpack --progress --color",


### PR DESCRIPTION
The package.json isn't pulling from the most recent version of Omnitone. (Version 1.05 vs. 1.2.4). 

https://www.npmjs.com/package/omnitone/v/1.2.4